### PR TITLE
add Contao Manager Plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,11 @@
         "php": ">=5.4.0",
         "contao/core-bundle": "~4.1"
     },
+    "require-dev": {
+         "contao/manager-plugin": "^2.0"
+    },
     "conflict": {
-        "contao/core": "*"
+        "contao/manager-plugin": "<2.0 || >=3.0"
     },
     "autoload": {
         "psr-4": {
@@ -29,6 +32,7 @@
     "extra": {
         "branch-alias": {
             "dev-develop": "4.2.x-dev"
-        }
+        },
+        "contao-manager-plugin": "Craffft\\CssStyleSelectorBundle\\ContaoManager\\Plugin"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
          "contao/manager-plugin": "^2.0"
     },
     "conflict": {
+        "contao/core": "*",
         "contao/manager-plugin": "<2.0 || >=3.0"
     },
     "autoload": {

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the CssStyleSelector Bundle.
+ *
+ * (c) Daniel Kiesel <https://github.com/iCodr8>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Craffft\CssStyleSelectorBundle\ContaoManager;
+
+use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
+use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
+use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
+
+/**
+ * Plugin for the Contao Manager.
+ *
+ * @author Fritz Michael Gschwantner <fmg@inspiredminds.at>
+ */
+class Plugin implements BundlePluginInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getBundles(ParserInterface $parser)
+    {
+        return [
+            BundleConfig::create('Craffft\CssStyleSelectorBundle\CraffftCssStyleSelectorBundle')
+                ->setLoadAfter(['Contao\CoreBundle\ContaoCoreBundle'])
+                ->setReplace(['css-style-selector']),
+        ];
+    }
+}


### PR DESCRIPTION
Currently this extension is not active within the Contao Managed Edition, since it's missing the Contao Manager Plugin.

This PR also removes the `contao/core` conflict - I think that's not really necessary.