### PR TITLE
load after rsce

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -11,9 +11,12 @@
 
 namespace Craffft\CssStyleSelectorBundle\ContaoManager;
 
-use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
+use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
+use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
+use Craffft\CssStyleSelectorBundle\CraffftCssStyleSelectorBundle;
+use MadeYourDay\RockSolidCustomElements\RockSolidCustomElementsBundle;
 
 /**
  * Plugin for the Contao Manager.
@@ -28,8 +31,8 @@ class Plugin implements BundlePluginInterface
     public function getBundles(ParserInterface $parser)
     {
         return [
-            BundleConfig::create('Craffft\CssStyleSelectorBundle\CraffftCssStyleSelectorBundle')
-                ->setLoadAfter(['Contao\CoreBundle\ContaoCoreBundle'])
+            BundleConfig::create(CraffftCssStyleSelectorBundle::class)
+                ->setLoadAfter([ContaoCoreBundle::class, RockSolidCustomElementsBundle::class])
                 ->setReplace(['css-style-selector']),
         ];
     }


### PR DESCRIPTION
I use both RSCE and the StyleSelector in almost all my projects - however one thing I always have to accommodate for is that the style selector is not available in the RockSolid Custom Elements. This simple change makes them available :)

_Note:_ this will __not__ create a hard dependency on RSCE. If the RSCE bundle is not present, nothing bad will happen ;)