### PR TITLE
Sort styles naturally

### DIFF
--- a/src/Models/CssStyleSelectorModel.php
+++ b/src/Models/CssStyleSelectorModel.php
@@ -98,6 +98,10 @@ class CssStyleSelectorModel extends Model
             ->prepare("SELECT id, styleDesignation AS styleDesignation FROM $t WHERE disableIn" . ucfirst($strType) . "=? ORDER BY styleDesignation ASC")
             ->execute(0);
 
-        return $objCssStyleSelector->fetchEach('styleDesignation');
+        $styles = $objCssStyleSelector->fetchEach('styleDesignation');
+
+        natsort($styles);
+
+        return $styles;
     }
 }


### PR DESCRIPTION
If you have styles with the following designations:

* Margin 1
* Margin 5
* Margin 10
* Margin 15
* Margin 20

then MySQL will sort it like this:

* Margin 1
* Margin 10
* Margin 15
* Margin 20
* Margin 5

I think it would make sense if the styles are sorted naturally for the select widget. However, there is no way to do this via MySQL, so it needs to be done with PHP's `natsort()` function.
