### PR TITLE
Update Plugin.php

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Craffft\CssStyleSelectorBundle\ContaoManager;
 
 use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\NewsBundle\ContaoNewsBundle;
+use Contao\CalendarBundle\ContaoCalendarBundle;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
@@ -26,7 +28,7 @@ class Plugin implements BundlePluginInterface
     {
         return [
             BundleConfig::create(CraffftCssStyleSelectorBundle::class)
-                ->setLoadAfter([ContaoCoreBundle::class, RockSolidCustomElementsBundle::class])
+                ->setLoadAfter([ContaoCoreBundle::class, ContaoNewsBundle::class, ContaoCalendarBundle::class, RockSolidCustomElementsBundle::class])
                 ->setReplace(['css-style-selector']),
         ];
     }


### PR DESCRIPTION
I had the problem that the bundle was loaded before the news and calendars bundle. Than the database fields in the news and calendar table was not created. I had this problem with contao 4.10 and also with contao 4.4 in combination with the nature theme.