### PR TITLE
Fix bundle order

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Craffft\CssStyleSelectorBundle\ContaoManager;
 
+use Contao\CalendarBundle\ContaoCalendarBundle;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
+use Contao\NewsBundle\ContaoNewsBundle;
 use Craffft\CssStyleSelectorBundle\CraffftCssStyleSelectorBundle;
 use MadeYourDay\RockSolidCustomElements\RockSolidCustomElementsBundle;
 
@@ -26,7 +28,12 @@ class Plugin implements BundlePluginInterface
     {
         return [
             BundleConfig::create(CraffftCssStyleSelectorBundle::class)
-                ->setLoadAfter([ContaoCoreBundle::class, RockSolidCustomElementsBundle::class])
+                ->setLoadAfter([
+                    ContaoCoreBundle::class, 
+                    ContaoNewsBundle::class,
+                    ContaoCalendarBundle::class,
+                    RockSolidCustomElementsBundle::class
+                ])
                 ->setReplace(['css-style-selector']),
         ];
     }


### PR DESCRIPTION
Since version `2.10` of the `contao/manager-plugin` the order of bundles is completely deterministic and not undefined any more.

`craffft/css-style-selector-bundle` also adjusts the DCA of `tl_news` and `tl_calendar_events`, if present. However, its Contao Manager Plugin is missing this soft dependency on the news- and calendar-bundle. Thus the DCA changes are never actually applied, because the bundle is might be loaded before the news- or calendar-bundle.

This PR fixes this and ensures that this bundle is always loaded after the news- and calendar-bundle, so that the DCA changes are taken into effect.