### PR TITLE
Fix bundle dependencies

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Craffft\CssStyleSelectorBundle\ContaoManager;
 
+use Contao\CalendarBundle\ContaoCalendarBundle;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
+use Contao\NewsBundle\ContaoNewsBundle;
 use Craffft\CssStyleSelectorBundle\CraffftCssStyleSelectorBundle;
 use MadeYourDay\RockSolidCustomElements\RockSolidCustomElementsBundle;
 
@@ -26,7 +28,12 @@ class Plugin implements BundlePluginInterface
     {
         return [
             BundleConfig::create(CraffftCssStyleSelectorBundle::class)
-                ->setLoadAfter([ContaoCoreBundle::class, RockSolidCustomElementsBundle::class])
+                ->setLoadAfter([
+                    ContaoCoreBundle::class, 
+                    ContaoNewsBundle::class,
+                    ContaoCalendarBundle::class,
+                    RockSolidCustomElementsBundle::class
+                ])
                 ->setReplace(['css-style-selector']),
         ];
     }


### PR DESCRIPTION
Since this bundle adjusts the DCA of `tl_news` and `tl_calendar_events`, you need to make sure that the bundle is loaded _after_ these bundles - otherwise the changes will have no effect. In fact it will lead to an error:

```
ErrorException:
Warning: Invalid argument supplied for foreach()

  at vendor/craffft/css-style-selector-bundle/src/Resources/contao/dca/tl_news.php:14
  at include('…\vendor\craffft\css-style-selector-bundle\src\Resources\contao\dca\tl_news.php')
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php:109)
  at Contao\DcaLoader->loadDcaFiles(false)
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php:70)
  at Contao\DcaLoader->load(false)
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php:1366)
  at Contao\Controller::loadDataContainer('tl_news')
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php:372)
  at Contao\DcaExtractor->createExtract()
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php:120)
  at Contao\DcaExtractor->__construct('tl_news')
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php:142)
  at Contao\DcaExtractor::getInstance('tl_news')
```