### PR TITLE
Fix warning in `tl_css_style_selector` DCA

### DIFF
--- a/src/Resources/contao/dca/tl_css_style_selector.php
+++ b/src/Resources/contao/dca/tl_css_style_selector.php
@@ -83,7 +83,7 @@ $GLOBALS['TL_DCA']['tl_css_style_selector'] = array
                 'label'               => &$GLOBALS['TL_LANG']['tl_css_style_selector']['delete'],
                 'href'                => 'act=delete',
                 'icon'                => 'delete.gif',
-                'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+                'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? '') . '\'))return false;Backend.getScrollOffset()"'
             ),
             'show' => array
             (


### PR DESCRIPTION
Fixes the following warning:

```
[ErrorException]
  Warning: Undefined array key "deleteConfirm"  


Exception trace:
  at vendor\craffft\css-style-selector-bundle\src\Resources\contao\dca\tl_css_style_selector.php:86
 include() at vendor\contao\core-bundle\src\Resources\contao\library\Contao\DcaLoader.php:120
```